### PR TITLE
Fix unintentional elementPath assignment

### DIFF
--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -274,7 +274,8 @@ class ProjectFindView extends View
         @model.replace(pathsPattern, replacePattern, @model.getPaths())
 
   directoryPathForElement: (element) ->
-    elementPath = element?.dataset.path ? element?.querySelector('[data-path]')?.dataset.path
+    if element?.dataset.path
+      elementPath = element?.querySelector('[data-path]')?.dataset.path
 
     # Traverse up the DOM if the element and its children don't have a path
     unless elementPath


### PR DESCRIPTION
I'm confused by the use of `?` after `element?.dataset.path`. (admittedly not a Coffeescript guy)

The problem I was having was if `element` was the `ol.tree-view` node, `element?.dataset.path` was undefined, but elementPath was _still_ getting assigned to the querySelector result, which ended up being the project root.

It seems like we want `elementPath` to remain undefined , so we can fall into the `unless elementPath` condition.